### PR TITLE
Add dark/light mode toggle for entire website

### DIFF
--- a/blocks/about-us/about-us.css
+++ b/blocks/about-us/about-us.css
@@ -9,14 +9,16 @@
 
 .about-us__title {
   margin: 0 0 0.5rem 0;
+  color: var(--text-color);
 }
 
 .about-us__lead {
   margin: 0;
+  color: var(--text-color);
 }
 
 .about-us__stats {
-  color: var(--color-gray-300, #bdbdbd);
+  color: var(--muted-color, #bdbdbd);
   font-size: 0.9rem;
 }
 
@@ -24,7 +26,7 @@
   background: transparent;
   padding: 6px 10px;
   border-radius: 999px;
-  border: 1px solid rgba(255,255,255,0.04);
+  border: 1px solid var(--card-border, rgba(255,255,255,0.04));
 }
 
 .about-us__features-grid {
@@ -38,8 +40,8 @@
   align-items: center;
   padding: 1rem;
   border-radius: var(--radius-md);
-  border: 1px solid rgba(255,255,255,0.06);
-  background: rgba(255,255,255,0.02);
+  border: 1px solid var(--card-border, rgba(255,255,255,0.06));
+  background: var(--card-bg, rgba(255,255,255,0.02));
   transition: transform var(--default-transition-duration) var(--default-transition-timing-function), box-shadow var(--default-transition-duration) var(--default-transition-timing-function);
 }
 
@@ -56,7 +58,7 @@
   justify-content: center;
   border-radius: 12px;
   background: linear-gradient(180deg, rgba(255,255,255,0.03), rgba(255,255,255,0.01));
-  color: var(--color-white, #fff);
+  color: var(--text-color);
 }
 
 .about-us__icon-svg {
@@ -66,10 +68,12 @@
 
 .about-us__card-title {
   margin: 0;
+  color: var(--text-color);
 }
 
 .about-us__card-desc {
   margin: 0;
+  color: var(--muted-color, #bdbdbd);
 }
 
 @media (width >= 900px) {

--- a/blocks/banner/banner.css
+++ b/blocks/banner/banner.css
@@ -1,0 +1,9 @@
+/* CTA button styling for banner */
+.cta-button {
+  border-width: 2px;
+  border-style: solid;
+  border-color: currentColor;
+  padding: 8px 16px;
+}
+
+/* Respect existing utilities: keep rounded-md, shadow, and hover behavior */

--- a/blocks/banner/banner.js
+++ b/blocks/banner/banner.js
@@ -15,7 +15,7 @@ export default function decorate(block) {
           A exclusive demo store made with goodness of AEM Edge Delivery Service and Shopify !! :)
         </p>
         <div class="mt-6 flex space-x-4">
-          <a href="#" class="inline-block rounded-md bg-white px-4 py-2 text-black font-medium shadow hover:bg-gray-100 transition">Shop Now</a>
+          <a href="#" class="inline-block rounded-md bg-white px-4 py-2 text-black font-medium shadow hover:bg-gray-100 transition cta-button">Shop Now</a>
         </div>
       </div>
     `;

--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -8,8 +8,9 @@
 }
 
 .cards > ul > li {
-  border: 1px solid #dadada;
-  background-color: var(--background-color);
+  border: 1px solid var(--card-border, #dadada);
+  background-color: var(--card-bg, var(--background-color));
+  color: var(--text-color);
 }
 
 .cards .cards-card-body {

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -282,6 +282,10 @@ header nav .nav-tools {
   color: inherit;
 }
 
+#theme-toggle {
+  border: 0.3px solid rgb(0,0,0);
+}
+
 .sr-only {
   position: absolute !important;
   width: 1px !important;

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -266,3 +266,30 @@ header nav .nav-sections ul > li > ul > li {
 header nav .nav-tools {
   grid-area: tools;
 }
+
+/* Theme toggle icons */
+#theme-toggle .theme-icon {
+  width: 18px;
+  height: 18px;
+  display: inline-block;
+  vertical-align: middle;
+}
+
+#theme-toggle .theme-icon svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+  color: inherit;
+}
+
+.sr-only {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0 0 0 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -32,8 +32,23 @@ export default async function decorate(block) {
   const getTheme = () => document.documentElement.getAttribute("data-theme") || "light";
 
   const toggleBtn = nav.querySelector("#theme-toggle");
+  // set icon markup (moon for dark, sun for light)
+  toggleBtn.innerHTML = `
+    <span class="theme-icon icon-moon" aria-hidden="true">
+      <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" fill="currentColor"/></svg>
+    </span>
+    <span class="theme-icon icon-sun" aria-hidden="true" style="display:none">
+      <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true"><path d="M6.76 4.84l-1.8-1.79L3.17 5.84l1.79 1.79 1.8-2.79zM1 13h3v-2H1v2zm10-9h2V1h-2v3zm7.03 1.05l1.79-1.79-1.79-1.79-1.79 1.79 1.79 1.79zM17 13h3v-2h-3v2zM6.76 19.16l-1.79 1.79 1.79 1.79 1.79-1.79-1.79-1.79zM11 20h2v3h-2v-3zM20.83 18.36l-1.79-1.79-1.79 1.79 1.79 1.79 1.79-1.79zM12 7a5 5 0 1 0 0 10 5 5 0 0 0 0-10z" fill="currentColor"/></svg>
+    </span>
+    <span class="sr-only">Toggle theme</span>
+  `;
+
   const updateToggleBtn = (theme) => {
-    toggleBtn.textContent = theme === "dark" ? "Light mode" : "Dark mode";
+    // theme: 'dark' means site is currently dark; button should indicate action (switch to light)
+    const moon = toggleBtn.querySelector('.icon-moon');
+    const sun = toggleBtn.querySelector('.icon-sun');
+    if (moon) moon.style.display = theme === 'dark' ? 'inline-block' : 'none';
+    if (sun) sun.style.display = theme === 'light' ? 'inline-block' : 'none';
     toggleBtn.setAttribute("aria-label", theme === "dark" ? "Switch to light mode" : "Switch to dark mode");
   };
 
@@ -45,7 +60,7 @@ export default async function decorate(block) {
     updateToggleBtn(theme);
   };
 
-  // initialize toggle label from current theme
+  // initialize toggle icon from current theme
   updateToggleBtn(getTheme());
 
   toggleBtn.addEventListener("click", () => {

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -8,11 +8,10 @@ export default async function decorate(block) {
 
   block.textContent = "";
   const nav = document.createElement("header");
-  nav.className = "bg-black text-white";
+  nav.className = "site-header";
   nav.innerHTML = `
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex items-center justify-between">
       <div class="flex items-center space-x-2">
-
         <span class="font-bold text-lg">Shopi Floyd</span>
       </div>
 
@@ -22,16 +21,45 @@ export default async function decorate(block) {
         <a href="#" class="hover:underline">Blogs</a>
       </nav>
 
+      <div class="flex items-center space-x-4">
+        <button id="theme-toggle" type="button" class="inline-flex items-center px-4 py-2 rounded-md outline transition"></button>
+      </div>
     </div>
 `;
 
   block.append(nav);
 
-  const toggleButton = nav.querySelector("#mobile-menu-toggle");
-  const mobileMenu = nav.querySelector("#mobile-menu");
-  if (toggleButton && mobileMenu) {
-    toggleButton.addEventListener("click", () => {
-      mobileMenu.classList.toggle("hidden");
-    });
-  }
+  const getTheme = () => document.documentElement.getAttribute("data-theme") || "light";
+
+  const applyHeaderTheme = (theme) => {
+    nav.classList.remove("bg-black", "text-white", "bg-white", "text-black", "shadow");
+    if (theme === "dark") {
+      nav.classList.add("bg-black", "text-white");
+    } else {
+      nav.classList.add("bg-white", "text-black", "shadow");
+    }
+  };
+
+  const toggleBtn = nav.querySelector("#theme-toggle");
+  const updateToggleBtn = (theme) => {
+    toggleBtn.textContent = theme === "dark" ? "Light mode" : "Dark mode";
+    toggleBtn.setAttribute("aria-label", theme === "dark" ? "Switch to light mode" : "Switch to dark mode");
+  };
+
+  const setTheme = (theme) => {
+    document.documentElement.setAttribute("data-theme", theme);
+    try {
+      localStorage.setItem("theme", theme);
+    } catch (e) {}
+    applyHeaderTheme(theme);
+    updateToggleBtn(theme);
+  };
+
+  applyHeaderTheme(getTheme());
+  updateToggleBtn(getTheme());
+
+  toggleBtn.addEventListener("click", () => {
+    const current = getTheme();
+    setTheme(current === "dark" ? "light" : "dark");
+  });
 }

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -31,15 +31,6 @@ export default async function decorate(block) {
 
   const getTheme = () => document.documentElement.getAttribute("data-theme") || "light";
 
-  const applyHeaderTheme = (theme) => {
-    nav.classList.remove("bg-black", "text-white", "bg-white", "text-black", "shadow");
-    if (theme === "dark") {
-      nav.classList.add("bg-black", "text-white");
-    } else {
-      nav.classList.add("bg-white", "text-black", "shadow");
-    }
-  };
-
   const toggleBtn = nav.querySelector("#theme-toggle");
   const updateToggleBtn = (theme) => {
     toggleBtn.textContent = theme === "dark" ? "Light mode" : "Dark mode";
@@ -51,11 +42,10 @@ export default async function decorate(block) {
     try {
       localStorage.setItem("theme", theme);
     } catch (e) {}
-    applyHeaderTheme(theme);
     updateToggleBtn(theme);
   };
 
-  applyHeaderTheme(getTheme());
+  // initialize toggle label from current theme
   updateToggleBtn(getTheme());
 
   toggleBtn.addEventListener("click", () => {

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -13,7 +13,7 @@
   max-width: 1200px;
   margin-left: auto;
   margin-right: auto;
-  color: var(--background-color);
+  color: var(--text-color);
 }
 
 .hero picture {

--- a/blocks/product-banner/product-banner.css
+++ b/blocks/product-banner/product-banner.css
@@ -1,0 +1,12 @@
+/* CTA buy button in product-banner */
+.cta-buy {
+  border-width: 3px;
+  border-style: solid;
+  border-color: currentColor;
+  padding: 8px 20px;
+}
+
+/* Ensure background/hover preserved */
+.cta-buy:hover {
+  background: rgba(0,0,0,0.04);
+}

--- a/blocks/product-banner/product-banner.js
+++ b/blocks/product-banner/product-banner.js
@@ -39,7 +39,7 @@ export default async function decorate(block) {
             <li>Free shipping and easy returns</li>
           </ul>
           <div class="mt-6 flex space-x-4">
-            <a href="#" class="inline-block rounded-md bg-white px-5 py-2 text-black font-medium shadow hover:bg-gray-100 transition">Buy Now</a>
+            <a href="#" class="inline-block rounded-md bg-white px-5 py-2 text-black font-medium shadow hover:bg-gray-100 transition cta-buy">Buy Now</a>
           </div>
         </div>
       </div>

--- a/blocks/product-carousel/product-carousel.css
+++ b/blocks/product-carousel/product-carousel.css
@@ -67,15 +67,13 @@
   padding: 12px 18px;
   border-radius: 12px;
   letter-spacing: 0.2px;
-  transition: background var(--default-transition-duration), color var(--default-transition-duration), transform var(--default-transition-duration), box-shadow var(--default-transition-duration);
-  box-shadow: 0 4px 12px rgba(0,0,0,0.45);
+  transition: background var(--default-transition-duration), color var(--default-transition-duration), transform var(--default-transition-duration);
 }
 
 .product-card__buy:hover {
   background: var(--buy-bg-hover, rgba(255,255,255,0.95));
   color: var(--text-color, #000);
   transform: translateY(-2px);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.6);
 }
 
 /* Dots */

--- a/blocks/product-carousel/product-carousel.css
+++ b/blocks/product-carousel/product-carousel.css
@@ -27,14 +27,13 @@
 .product-card {
   background: var(--card-bg, linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.01)));
   border: 1px solid var(--card-border, rgba(255,255,255,0.06));
-  transition: transform var(--default-transition-duration) var(--default-transition-timing-function), box-shadow var(--default-transition-duration) var(--default-transition-timing-function);
+  transition: transform var(--default-transition-duration) var(--default-transition-timing-function);
   padding: 0.75rem;
   color: var(--text-color);
 }
 
 .product-card:hover {
   transform: translateY(-8px);
-  box-shadow: 0 14px 36px rgba(0,0,0,0.6);
 }
 
 .product-card__image {

--- a/blocks/product-carousel/product-carousel.css
+++ b/blocks/product-carousel/product-carousel.css
@@ -25,10 +25,11 @@
 }
 
 .product-card {
-  background: linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.01));
-  border: 1px solid rgba(255,255,255,0.06);
+  background: var(--card-bg, linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.01)));
+  border: 1px solid var(--card-border, rgba(255,255,255,0.06));
   transition: transform var(--default-transition-duration) var(--default-transition-timing-function), box-shadow var(--default-transition-duration) var(--default-transition-timing-function);
   padding: 0.75rem;
+  color: var(--text-color);
 }
 
 .product-card:hover {
@@ -55,14 +56,14 @@
 
 .product-card__price {
   margin: 0 0 10px 0;
-  color: var(--color-gray-400, #bdbdbd);
+  color: var(--muted-color, var(--color-gray-400, #bdbdbd));
 }
 
-/* White outlined Buy button with more space around it */
+/* Buy button uses theme variables */
 .product-card__buy {
   display: inline-block;
-  border: 1.5px solid rgba(255,255,255,0.95);
-  color: var(--color-white, #fff);
+  border: 1.5px solid var(--buy-border, rgba(255,255,255,0.95));
+  color: var(--buy-color, var(--color-white, #fff));
   background: transparent;
   padding: 12px 18px;
   border-radius: 12px;
@@ -72,8 +73,8 @@
 }
 
 .product-card__buy:hover {
-  background: rgba(255,255,255,0.95);
-  color: #000;
+  background: var(--buy-bg-hover, rgba(255,255,255,0.95));
+  color: var(--text-color, #000);
   transform: translateY(-2px);
   box-shadow: 0 10px 30px rgba(0,0,0,0.6);
 }
@@ -91,16 +92,16 @@
   width: 12px;
   height: 12px;
   border-radius: 999px;
-  border: 1px solid rgba(255,255,255,0.12);
+  border: 1px solid var(--dot-border, rgba(255,255,255,0.12));
   background: transparent;
   padding: 0;
   transition: transform var(--default-transition-duration), background var(--default-transition-duration), border-color var(--default-transition-duration);
 }
 
 .product-carousel__dot.active {
-  background: linear-gradient(90deg, rgba(255,255,255,0.95), rgba(255,255,255,0.75));
+  background: var(--dot-active-bg, linear-gradient(90deg, rgba(255,255,255,0.95), rgba(255,255,255,0.75)));
   transform: scale(1.15);
-  border-color: rgba(255,255,255,0.95);
+  border-color: var(--dot-border, rgba(255,255,255,0.95));
 }
 
 @media (width >= 900px) {

--- a/blocks/product-carousel/product-carousel.css
+++ b/blocks/product-carousel/product-carousel.css
@@ -61,10 +61,10 @@
 /* Buy button uses theme variables */
 .product-card__buy {
   display: inline-block;
-  border: 1.5px solid var(--buy-border, rgba(255,255,255,0.95));
+  border: 3px solid var(--buy-border, rgba(255,255,255,0.95));
   color: var(--buy-color, var(--color-white, #fff));
   background: transparent;
-  padding: 12px 18px;
+  padding: 8px 20px;
   border-radius: 12px;
   letter-spacing: 0.2px;
   transition: background var(--default-transition-duration), color var(--default-transition-duration), transform var(--default-transition-duration);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -89,6 +89,18 @@ export function decorateMain(main) {
  * Loads everything needed to get to LCP.
  * @param {Element} doc The container element
  */
+// Initialize theme early based on localStorage or system preference
+(function initTheme() {
+  try {
+    const stored = localStorage.getItem('theme');
+    const systemDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const initial = stored || (systemDark ? 'dark' : 'light');
+    document.documentElement.setAttribute('data-theme', initial);
+  } catch (e) {
+    document.documentElement.setAttribute('data-theme', 'light');
+  }
+})();
+
 async function loadEager(doc) {
   document.documentElement.lang = "en";
   decorateTemplateAndTheme();

--- a/styles/lazy-styles.css
+++ b/styles/lazy-styles.css
@@ -52,6 +52,34 @@ body {
 .product-carousel__dot.active { background: var(--dot-active-bg); }
 
 /* Ensure legacy utility classes like .bg-black / .text-white follow the active theme */
+
+/* Button styles for light mode */
+html[data-theme="light"] {
+  --button-outline-color: #000;
+  --button-text-color: #000;
+  --button-bg-hover: rgba(0,0,0,0.04);
+}
+
+html[data-theme="light"] button,
+html[data-theme="light"] input[type="button"],
+html[data-theme="light"] input[type="submit"],
+html[data-theme="light"] a.button,
+html[data-theme="light"] .product-card__buy,
+html[data-theme="light"] #theme-toggle {
+  border: 1.5px solid var(--button-outline-color) !important;
+  background: transparent !important;
+  color: var(--button-text-color) !important;
+}
+
+html[data-theme="light"] button:hover,
+html[data-theme="light"] input[type="button"]:hover,
+html[data-theme="light"] input[type="submit"]:hover,
+html[data-theme="light"] a.button:hover,
+html[data-theme="light"] .product-card__buy:hover,
+html[data-theme="light"] #theme-toggle:hover {
+  background: var(--button-bg-hover) !important;
+}
+
 html[data-theme="light"] .bg-black { background-color: var(--background-color) !important; }
 html[data-theme="light"] .text-white { color: var(--text-color) !important; }
 html[data-theme="light"] .bg-black *, html[data-theme="light"] .bg-black *:not(svg) { color: inherit; }

--- a/styles/lazy-styles.css
+++ b/styles/lazy-styles.css
@@ -1,1 +1,17 @@
 /* add global styles that can be loaded post LCP here */
+
+/* Theme base */
+html[data-theme="dark"] body { background-color: var(--color-black); color: var(--color-white); }
+html[data-theme="light"] body { background-color: var(--color-white); color: var(--color-black); }
+
+/* Light mode tweaks for components designed for dark backgrounds */
+html[data-theme="light"] .product-card { background: linear-gradient(180deg, rgba(0,0,0,0.02), rgba(0,0,0,0.01)); border: 1px solid rgba(0,0,0,0.06); }
+html[data-theme="light"] .product-card__buy { border: 1.5px solid rgba(0,0,0,0.85); color: #000; box-shadow: 0 4px 12px rgba(0,0,0,0.1); }
+html[data-theme="light"] .product-card__buy:hover { background: rgba(0,0,0,0.9); color: #fff; box-shadow: 0 10px 30px rgba(0,0,0,0.2); }
+
+html[data-theme="light"] .product-carousel__dot { border: 1px solid rgba(0,0,0,0.2); }
+html[data-theme="light"] .product-carousel__dot.active { background: linear-gradient(90deg, rgba(0,0,0,0.9), rgba(0,0,0,0.75)); border-color: rgba(0,0,0,0.9); }
+
+html[data-theme="light"] .about-us__stat { border: 1px solid rgba(0,0,0,0.08); }
+html[data-theme="light"] .about-us__card { border: 1px solid rgba(0,0,0,0.08); background: rgba(0,0,0,0.02); box-shadow: none; }
+html[data-theme="light"] .about-us__icon { background: linear-gradient(180deg, rgba(0,0,0,0.04), rgba(0,0,0,0.02)); color: var(--color-black, #000); }

--- a/styles/lazy-styles.css
+++ b/styles/lazy-styles.css
@@ -1,8 +1,29 @@
 /* add global styles that can be loaded post LCP here */
 
 /* Theme base */
-html[data-theme="dark"] body { background-color: var(--color-black); color: var(--color-white); }
-html[data-theme="light"] body { background-color: var(--color-white); color: var(--color-black); }
+html[data-theme="dark"] {
+  --background-color: var(--color-black);
+  --light-color: #0b0b0b;
+  --text-color: var(--color-white);
+  --nav-background: var(--background-color);
+}
+
+html[data-theme="light"] {
+  --background-color: var(--color-white);
+  --light-color: var(--color-gray-100, #f5f5f5);
+  --text-color: var(--color-black);
+  --nav-background: var(--background-color);
+}
+
+/* Apply to page */
+body {
+  background-color: var(--background-color);
+  color: var(--text-color);
+  transition: background-color var(--default-transition-duration) var(--default-transition-timing-function), color var(--default-transition-duration) var(--default-transition-timing-function);
+}
+
+/* Ensure header/nav pick up nav background via variable */
+.site-header { background-color: var(--nav-background); color: var(--text-color); }
 
 /* Light mode tweaks for components designed for dark backgrounds */
 html[data-theme="light"] .product-card { background: linear-gradient(180deg, rgba(0,0,0,0.02), rgba(0,0,0,0.01)); border: 1px solid rgba(0,0,0,0.06); }

--- a/styles/lazy-styles.css
+++ b/styles/lazy-styles.css
@@ -51,5 +51,13 @@ body {
 .product-carousel__dot { border: 1px solid var(--dot-border); }
 .product-carousel__dot.active { background: var(--dot-active-bg); }
 
+/* Ensure legacy utility classes like .bg-black / .text-white follow the active theme */
+html[data-theme="light"] .bg-black { background-color: var(--background-color) !important; }
+html[data-theme="light"] .text-white { color: var(--text-color) !important; }
+html[data-theme="light"] .bg-black *, html[data-theme="light"] .bg-black *:not(svg) { color: inherit; }
+
+html[data-theme="dark"] .bg-white { background-color: var(--background-color) !important; }
+html[data-theme="dark"] .text-black { color: var(--text-color) !important; }
+
 /* Keep previous light-mode specific rules for legacy selectors if needed */
 html[data-theme="light"] .product-carousel__dot.active { /* ensure contrast */ }

--- a/styles/lazy-styles.css
+++ b/styles/lazy-styles.css
@@ -1,18 +1,32 @@
 /* add global styles that can be loaded post LCP here */
 
-/* Theme base */
+/* Theme base - define many variables that components will consume */
 html[data-theme="dark"] {
   --background-color: var(--color-black);
   --light-color: #0b0b0b;
   --text-color: var(--color-white);
-  --nav-background: var(--background-color);
+  --muted-color: var(--color-gray-300);
+  --card-bg: rgba(255,255,255,0.02);
+  --card-border: rgba(255,255,255,0.06);
+  --buy-border: rgba(255,255,255,0.95);
+  --buy-color: var(--color-white);
+  --buy-bg-hover: rgba(255,255,255,0.95);
+  --dot-border: rgba(255,255,255,0.12);
+  --dot-active-bg: linear-gradient(90deg, rgba(255,255,255,0.95), rgba(255,255,255,0.75));
 }
 
 html[data-theme="light"] {
   --background-color: var(--color-white);
   --light-color: var(--color-gray-100, #f5f5f5);
   --text-color: var(--color-black);
-  --nav-background: var(--background-color);
+  --muted-color: var(--color-gray-400);
+  --card-bg: rgba(0,0,0,0.02);
+  --card-border: rgba(0,0,0,0.06);
+  --buy-border: rgba(0,0,0,0.85);
+  --buy-color: #000;
+  --buy-bg-hover: rgba(0,0,0,0.9);
+  --dot-border: rgba(0,0,0,0.2);
+  --dot-active-bg: linear-gradient(90deg, rgba(0,0,0,0.9), rgba(0,0,0,0.75));
 }
 
 /* Apply to page */
@@ -23,16 +37,19 @@ body {
 }
 
 /* Ensure header/nav pick up nav background via variable */
-.site-header { background-color: var(--nav-background); color: var(--text-color); }
+.site-header { background-color: var(--nav-background, var(--background-color)); color: var(--text-color); }
 
-/* Light mode tweaks for components designed for dark backgrounds */
-html[data-theme="light"] .product-card { background: linear-gradient(180deg, rgba(0,0,0,0.02), rgba(0,0,0,0.01)); border: 1px solid rgba(0,0,0,0.06); }
-html[data-theme="light"] .product-card__buy { border: 1.5px solid rgba(0,0,0,0.85); color: #000; box-shadow: 0 4px 12px rgba(0,0,0,0.1); }
-html[data-theme="light"] .product-card__buy:hover { background: rgba(0,0,0,0.9); color: #fff; box-shadow: 0 10px 30px rgba(0,0,0,0.2); }
+/* Fallback component tweaks kept in components, but also allow per-block overrides via variables */
 
-html[data-theme="light"] .product-carousel__dot { border: 1px solid rgba(0,0,0,0.2); }
-html[data-theme="light"] .product-carousel__dot.active { background: linear-gradient(90deg, rgba(0,0,0,0.9), rgba(0,0,0,0.75)); border-color: rgba(0,0,0,0.9); }
+/* Generic helpers used by blocks */
+.block { color: var(--text-color); }
 
-html[data-theme="light"] .about-us__stat { border: 1px solid rgba(0,0,0,0.08); }
-html[data-theme="light"] .about-us__card { border: 1px solid rgba(0,0,0,0.08); background: rgba(0,0,0,0.02); box-shadow: none; }
-html[data-theme="light"] .about-us__icon { background: linear-gradient(180deg, rgba(0,0,0,0.04), rgba(0,0,0,0.02)); color: var(--color-black, #000); }
+/* Small overrides kept for compatibility */
+.product-card__price { color: var(--muted-color, #bdbdbd); }
+.product-card__buy { border: 1.5px solid var(--buy-border); color: var(--buy-color); }
+.product-card__buy:hover { background: var(--buy-bg-hover); color: var(--text-color); }
+.product-carousel__dot { border: 1px solid var(--dot-border); }
+.product-carousel__dot.active { background: var(--dot-active-bg); }
+
+/* Keep previous light-mode specific rules for legacy selectors if needed */
+html[data-theme="light"] .product-carousel__dot.active { /* ensure contrast */ }


### PR DESCRIPTION
## Purpose

The user requested to add dark and light mode functionality to the website. Initially, the toggle was only affecting the header, but the user wanted the theme switching to apply to the entire webpage for a consistent user experience across all components.

## Code changes

- **Header component**: Added theme toggle button with proper accessibility attributes and removed hardcoded dark styling
- **Theme initialization**: Added early theme detection in `scripts.js` that checks localStorage and system preferences to set initial theme
- **Global styling**: Implemented comprehensive CSS variables and theme-specific styles in `lazy-styles.css` that apply to the entire page including:
  - Background and text color variables for both themes
  - Smooth transitions between theme changes
  - Component-specific styling adjustments for product cards, carousels, and about sections
  - Proper contrast and visual hierarchy for both light and dark modes

The implementation now provides a complete theme switching experience that persists user preferences and affects all page elements.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/94689aa27bd4475c9cfce5faed5532e6/neon-hub)

👀 [Preview Link](https://94689aa27bd4475c9cfce5faed5532e6-neon-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>94689aa27bd4475c9cfce5faed5532e6</projectId>-->
<!--<branchName>neon-hub</branchName>-->